### PR TITLE
Add estimateGas to DeferredTransactionWrapper

### DIFF
--- a/runtime/typechain-runtime.ts
+++ b/runtime/typechain-runtime.ts
@@ -35,6 +35,21 @@ export class DeferredTransactionWrapper<T extends ITxParams> {
     private readonly methodName: string,
     private readonly methodArgs: any[],
   ) {}
+  
+  estimateGas(params: T, customWeb3?: any): Promise<number> {
+    let method: any;
+
+    if (customWeb3) {
+      const tmpContract = customWeb3.eth
+        .contract(this.parentContract.contractAbi)
+        .at(this.parentContract.address);
+      method = tmpContract[this.methodName].estimateGas;
+    } else {
+      method = this.parentContract.rawWeb3Contract[this.methodName].estimateGas;
+    }
+
+    return promisify(method, [...this.methodArgs, params]);
+  }
 
   send(params: T, customWeb3?: any): Promise<string> {
     let method: any;


### PR DESCRIPTION
It would be great to have a way to call estimateGas through this interface. Ideally this would be called in the send process but for now this could be a good start to assist people pass more specific gas estimates instead of standard gas limits per the example.